### PR TITLE
Check what the method actually returns and what the docblock says it ret...

### DIFF
--- a/library/Xi/Filelib/Backend/Doctrine2Backend.php
+++ b/library/Xi/Filelib/Backend/Doctrine2Backend.php
@@ -129,7 +129,7 @@ class Doctrine2Backend extends AbstractBackend
      * Finds a file
      *
      * @param  integer                        $id
-     * @return \Xi\Filelib\File\File|false
+     * @return array|false
      */
     public function findFile($id)
     {
@@ -268,7 +268,7 @@ class Doctrine2Backend extends AbstractBackend
      * Finds folder
      *
      * @param  integer                          $id
-     * @return \Xi\Filelib\Folder\Folder|false
+     * @return array|false
      */
     public function findFolder($id)
     {


### PR DESCRIPTION
...urns. Some methods returns an array yet the docblock says it returns an xyzIterator. Is this intentionally or buggy documentation?
