### PR TITLE
Removed Filelibrary dependency from Linkers

### DIFF
--- a/library/Xi/Filelib/File/DefaultFileOperator.php
+++ b/library/Xi/Filelib/File/DefaultFileOperator.php
@@ -104,7 +104,6 @@ class DefaultFileOperator extends AbstractOperator implements FileOperator
         }
         $this->profiles[$identifier] = $profile;
         $profile->setFilelib($this->getFilelib());
-        $profile->getLinker()->setFilelib($this->getFilelib());
 
         $this->getEventDispatcher()->addSubscriber($profile);
 

--- a/library/Xi/Filelib/Linker/AbstractLinker.php
+++ b/library/Xi/Filelib/Linker/AbstractLinker.php
@@ -9,49 +9,18 @@
 
 namespace Xi\Filelib\Linker;
 
-use Xi\Filelib\Linker\Linker,
-    Xi\Filelib\FileLibrary,
-    Xi\Filelib\Configurator
-    ;
+use Xi\Filelib\Linker\Linker;
+use Xi\Filelib\Configurator;
 
 /**
- * An abstract linker class with common methods implemented.
+ * An abstract linker class.
  *
  * @author pekkis
- *
  */
 abstract class AbstractLinker implements Linker
 {
-    
     public function __construct($options = array())
     {
         Configurator::setConstructorOptions($this, $options);
-    }
-    
-    /**
-     * @var FileLibrary Filelib
-     */
-    protected $filelib;
-
-    /**
-     * Sets filelib
-     * 
-     * @return Linker
-     *
-     */
-    public function setFilelib(FileLibrary $filelib)
-    {
-        $this->filelib = $filelib;
-        return $this;
-    }
-
-    /**
-     * Returns filelib
-     *
-     * @return FileLibrary
-     */
-    public function getFilelib()
-    {
-        return $this->filelib;
     }
 }

--- a/library/Xi/Filelib/Linker/BeautifurlLinker.php
+++ b/library/Xi/Filelib/Linker/BeautifurlLinker.php
@@ -15,16 +15,15 @@ use Xi\Filelib\File\File;
 use Xi\Filelib\Folder\Folder;
 use Xi\Filelib\Plugin\VersionProvider\VersionProvider;
 use Xi\Filelib\Tool\Slugifier\Slugifier;
+use Xi\Filelib\Folder\FolderOperator;
 
 /**
  * Creates beautifurls(tm) from the virtual directory structure and file names.
  *
  * @author pekkis
- *
  */
 class BeautifurlLinker extends AbstractLinker implements Linker
 {
-
     /**
      * @var boolean Exclude root folder from beautifurls or not
      */
@@ -35,6 +34,20 @@ class BeautifurlLinker extends AbstractLinker implements Linker
     private $slugifier;
 
     private $slugify = true;
+
+    /**
+     * @var FolderOperator
+     */
+    private $folderOperator;
+
+    /**
+     * @param  FolderOperator   $folderOperator
+     * @return BeautifurlLinker
+     */
+    public function __construct(FolderOperator $folderOperator)
+    {
+        $this->folderOperator = $folderOperator;
+    }
 
     /**
      * Sets whether the root folder is excluded from beautifurls.
@@ -133,10 +146,10 @@ class BeautifurlLinker extends AbstractLinker implements Linker
     public function getLink(File $file)
     {
         $folders = array();
-        $folders[] = $folder = $this->getFilelib()->getFolderOperator()->find($file->getFolderId());
+        $folders[] = $folder = $this->folderOperator->find($file->getFolderId());
 
         while($folder->getParentId()) {
-            $folder = $this->getFilelib()->getFolderOperator()->find($folder->getParentId());
+            $folder = $this->folderOperator->find($folder->getParentId());
             array_unshift($folders, $folder);
         }
 

--- a/library/Xi/Filelib/Linker/Linker.php
+++ b/library/Xi/Filelib/Linker/Linker.php
@@ -9,40 +9,22 @@
 
 namespace Xi\Filelib\Linker;
 
-use \Xi\Filelib\FileLibrary,
-    \Xi\Filelib\File\File,
-    \Xi\Filelib\Plugin\VersionProvider\VersionProvider
-    ;
+use Xi\Filelib\File\File;
 
 /**
  * Linker interface
  *
  * @author pekkis
- *
+ * @author Mikko Hirvonen <mikko.petteri.hirvonen@gmail.com>
  */
 interface Linker
 {
-
-    /**
-     * Sets filelib
-     *
-     * @return Linker
-     */
-    public function setFilelib(FileLibrary $filelib);
-
-    /**
-     * Returns filelib
-     *
-     * @return FileLibrary
-     */
-    public function getFilelib();
-
     /**
      * Returns link for a version of a file
      *
-     * @param File $file
-     * @param string $version Version identifier
-     * @param string $extension Extension
+     * @param  File   $file
+     * @param  string $version Version identifier
+     * @param  string $extension Extension
      * @return string Versioned link
      */
     public function getLinkVersion(File $file, $version, $extension);
@@ -50,7 +32,7 @@ interface Linker
     /**
      * Returns a link for a file
      *
-     * @param File $file
+     * @param  File   $file
      * @return string Link
      */
     public function getLink(File $file);

--- a/tests/Xi/Tests/Filelib/File/DefaultFileOperatorTest.php
+++ b/tests/Xi/Tests/Filelib/File/DefaultFileOperatorTest.php
@@ -227,19 +227,11 @@ class DefaultFileOperatorTest extends \Xi\Tests\Filelib\TestCase
 
         $this->assertEquals(array(), $op->getProfiles());
 
-        $linker = $this->getMockForAbstractClass('Xi\Filelib\Linker\Linker');
-        $linker->expects($this->once())->method('setFilelib')->with($this->equalTo($filelib));
-
-        $linker2 = $this->getMockForAbstractClass('Xi\Filelib\Linker\Linker');
-        $linker2->expects($this->once())->method('setFilelib')->with($this->equalTo($filelib));
-
         $profile = $this->getMock('Xi\Filelib\File\FileProfile');
         $profile->expects($this->any())->method('getIdentifier')->will($this->returnValue('xooxer'));
-        $profile->expects($this->any())->method('getLinker')->will($this->returnValue($linker));
 
         $profile2 = $this->getMock('Xi\Filelib\File\FileProfile');
         $profile2->expects($this->any())->method('getIdentifier')->will($this->returnValue('lusser'));
-        $profile2->expects($this->any())->method('getLinker')->will($this->returnValue($linker2));
 
         $eventDispatcher->expects($this->exactly(2))->method('addSubscriber')->with($this->isInstanceOf('Xi\Filelib\File\FileProfile'));
 
@@ -254,7 +246,6 @@ class DefaultFileOperatorTest extends \Xi\Tests\Filelib\TestCase
 
         $this->assertSame($profile, $op->getProfile('xooxer'));
         $this->assertSame($profile2, $op->getProfile('lusser'));
-
     }
 
     /**

--- a/tests/Xi/Tests/Filelib/Linker/AbstractLinkerTest.php
+++ b/tests/Xi/Tests/Filelib/Linker/AbstractLinkerTest.php
@@ -11,24 +11,19 @@ namespace Xi\Tests\Filelib\Linker;
 
 use Xi\Tests\Filelib\TestCase;
 
+/**
+ * @group linker
+ */
 class AbstractLinkerTest extends TestCase
 {
-    
     /**
      * @test
      */
-    public function gettersAndSettersShouldWorkAsExpected()
+    public function implementsLinker()
     {
-        $linker = $this->getMockBuilder('Xi\Filelib\Linker\AbstractLinker')
-                    ->setMethods(array('getLink', 'getLinkVersion'))
-                    ->getMockForAbstractClass();
-        
-        $this->assertNull($linker->getFilelib());
-                        
-        $filelib = $this->getMock('Xi\Filelib\FileLibrary');
-        
-        $this->assertSame($linker, $linker->setFilelib($filelib));
-        
-        $this->assertSame($filelib, $linker->getFilelib());
+        $this->assertContains(
+            'Xi\Filelib\Linker\Linker',
+            class_implements('Xi\Filelib\Linker\AbstractLinker')
+        );
     }
 }

--- a/tests/Xi/Tests/Filelib/Linker/BeautifurlLinkerTest.php
+++ b/tests/Xi/Tests/Filelib/Linker/BeautifurlLinkerTest.php
@@ -13,18 +13,20 @@ use Xi\Filelib\Folder\Folder;
 use Xi\Filelib\File\File;
 use Xi\Filelib\Linker\BeautifurlLinker;
 
+/**
+ * @group linker
+ */
 class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
 {
-
-    protected $filelib;
+    private $linker;
 
     public function setUp()
     {
-        if (!class_exists('\\Zend\\Filter\\FilterChain')) {
+        if (!class_exists('Zend\Filter\FilterChain')) {
             $this->markTestSkipped('Zend Framework 2 filters not loadable');
         }
 
-        $fo = $this->getMockBuilder('\Xi\Filelib\Folder\FolderOperator')->getMock();
+        $fo = $this->getMock('Xi\Filelib\Folder\FolderOperator');
         $fo->expects($this->any())
              ->method('find')
              ->will($this->returnCallback(function($id) {
@@ -82,34 +84,8 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
 
              }));
 
-
-
-        $this->fo = $fo;
-
-
-        $this->filelib = $this->getFilelib();
-
-        $this->filelib->setFolderOperator($fo);
-
-        $vp = $this->getMock('\Xi\Filelib\Plugin\VersionProvider\VersionProvider');
-        $vp->expects($this->any())
-             ->method('getIdentifier')
-             ->will($this->returnValue('xoo'));
-
-        $vp->expects($this->any())
-             ->method('getExtensionFor')
-             ->with($this->equalTo('xoo'))
-             ->will($this->returnValue('xoo'));
-
-
-
-        $this->versionProvider = $vp;
-
-
-
+        $this->linker = new BeautifurlLinker($fo);
     }
-
-
 
     public function provideFiles()
     {
@@ -150,65 +126,62 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
         );
     }
 
-
-
     /**
      * @test
      * @dataProvider provideFiles
      */
     public function linkerShouldCreateProperBeautifurlLinks($file, $beautifurl)
     {
-        $linker = new BeautifurlLinker();
-        $linker->setFilelib($this->filelib);
-        $linker->setExcludeRoot(true);
-        $linker->setSlugify(true);
+        $this->linker->setExcludeRoot(true);
+        $this->linker->setSlugify(true);
 
-        $this->assertEquals($beautifurl[0], $linker->getLink($file, true));
-
+        $this->assertEquals($beautifurl[0], $this->linker->getLink($file, true));
     }
 
     /**
-     *
-     *
      * @test
      * @dataProvider provideFiles
      */
     public function versionLinkerShouldCreateProperBeautifurlLinks($file, $beautifurl)
     {
-        $linker = new BeautifurlLinker();
-        $linker->setFilelib($this->filelib);
-        $linker->setExcludeRoot(true);
-        $linker->setSlugify(true);
+        $this->linker->setExcludeRoot(true);
+        $this->linker->setSlugify(true);
 
-        $this->assertEquals($beautifurl[1], $linker->getLinkVersion($file, $this->versionProvider->getIdentifier(), $this->versionProvider->getExtensionFor($this->versionProvider->getIdentifier())));
+        $versionProvider = $this->getMock('\Xi\Filelib\Plugin\VersionProvider\VersionProvider');
+        $versionProvider->expects($this->any())
+                        ->method('getIdentifier')
+                        ->will($this->returnValue('xoo'));
 
+        $versionProvider->expects($this->any())
+                        ->method('getExtensionFor')
+                        ->with($this->equalTo('xoo'))
+                        ->will($this->returnValue('xoo'));
+
+        $this->assertEquals(
+            $beautifurl[1],
+            $this->linker->getLinkVersion(
+                $file,
+                $versionProvider->getIdentifier(),
+                $versionProvider->getExtensionFor($versionProvider->getIdentifier())
+            )
+        );
     }
-
-
-
-
 
     /**
      * @test
      */
     public function linkerShouldExcludeRootProperly()
     {
-
-        $linker = new BeautifurlLinker();
-        $linker->setFilelib($this->filelib);
-
-
         $file = File::create(array(
             'name' => 'lamantiini.lus',
             'folder_id' => 2,
         ));
 
-        $linker->setExcludeRoot(false);
-        $this->assertEquals('root/lussuttaja/lamantiini.lus', $linker->getLink($file));
+        $this->linker->setExcludeRoot(false);
+        $this->assertEquals('root/lussuttaja/lamantiini.lus', $this->linker->getLink($file));
 
-        $linker->setExcludeRoot(true);
-        $this->assertEquals('lussuttaja/lamantiini.lus', $linker->getLink($file));
-
+        $this->linker->setExcludeRoot(true);
+        $this->assertEquals('lussuttaja/lamantiini.lus', $this->linker->getLink($file));
     }
 
     /**
@@ -216,20 +189,17 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
      */
     public function linkerShouldNotSlugifyWhenSlugifyIsSetToFalse()
     {
+        $this->linker->setSlugify(false);
 
-        $linker = new BeautifurlLinker();
-        $linker->setSlugify(false);
-        $linker->setFilelib($this->filelib);
-
-         $file = File::create(array(
+        $file = File::create(array(
             'name' => 'lamantiini.lus',
             'folder_id' => 5,
         ));
 
-
-        $this->assertEquals('root/lussuttaja/banaanin/sûürën ÜGRÎLÄISÊN KÄNSÄN SïëLú/lamantiini.lus', $linker->getLink($file));
-
-
+        $this->assertEquals(
+            'root/lussuttaja/banaanin/sûürën ÜGRÎLÄISÊN KÄNSÄN SïëLú/lamantiini.lus',
+            $this->linker->getLink($file)
+        );
     }
 
     /**
@@ -237,25 +207,21 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
      */
     public function slugifierClassShouldDefaultToZf2Slugifier()
     {
-        $linker = new BeautifurlLinker();
-        $this->assertEquals('Xi\Filelib\Tool\Slugifier\Zend2Slugifier', $linker->getSlugifierClass());
+        $this->assertEquals(
+            'Xi\Filelib\Tool\Slugifier\Zend2Slugifier',
+            $this->linker->getSlugifierClass()
+        );
     }
-
 
     /**
      * @test
      */
     public function slugifierClassSetterAndGetterShouldWorkAsExpected()
     {
-        $linker = new BeautifurlLinker();
-        $this->assertEquals('Xi\Filelib\Tool\Slugifier\Zend2Slugifier', $linker->getSlugifierClass());
-
         $newSlugifierClass = 'Lussen\Tussen\Hofenslussifier';
 
-        $this->assertSame($linker, $linker->setSlugifierClass($newSlugifierClass));
-
-        $this->assertEquals($newSlugifierClass, $linker->getSlugifierClass());
-
+        $this->assertSame($this->linker, $this->linker->setSlugifierClass($newSlugifierClass));
+        $this->assertEquals($newSlugifierClass, $this->linker->getSlugifierClass());
     }
 
     /**
@@ -263,10 +229,9 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
      */
     public function excludeRootSetterAndGetterShouldWorkAsExpected()
     {
-         $linker = new BeautifurlLinker();
-         $this->assertFalse($linker->getExcludeRoot());
-         $this->assertSame($linker, $linker->setExcludeRoot(true));
-         $this->assertTrue($linker->getExcludeRoot());
+         $this->assertFalse($this->linker->getExcludeRoot());
+         $this->assertSame($this->linker, $this->linker->setExcludeRoot(true));
+         $this->assertTrue($this->linker->getExcludeRoot());
     }
 
     /**
@@ -274,35 +239,26 @@ class BeautifurlLinkerTest extends \Xi\Tests\Filelib\TestCase
      */
     public function slugifyRootSetterAndGetterShouldWorkAsExpected()
     {
-         $linker = new BeautifurlLinker();
-         $this->assertTrue($linker->getSlugify());
-         $this->assertSame($linker, $linker->setSlugify(false));
-         $this->assertFalse($linker->getSlugify());
+         $this->assertTrue($this->linker->getSlugify());
+         $this->assertSame($this->linker, $this->linker->setSlugify(false));
+         $this->assertFalse($this->linker->getSlugify());
     }
-
 
     /**
      * @test
      */
     public function getSlugifierShouldInstantiateAndCacheSlugifierObject()
     {
-        $linker = new BeautifurlLinker();
-
         $mockSlugifierClass = $this->getMockClass('Xi\Filelib\Tool\Slugifier\Slugifier');
 
-        $linker->setSlugifierClass($mockSlugifierClass);
+        $this->linker->setSlugifierClass($mockSlugifierClass);
 
-        $slugifier = $linker->getSlugifier();
+        $slugifier = $this->linker->getSlugifier();
 
         $this->assertSame($mockSlugifierClass, get_class($slugifier));
 
-        $slugifier2 = $linker->getSlugifier();
+        $slugifier2 = $this->linker->getSlugifier();
 
         $this->assertSame($slugifier, $slugifier2);
-
     }
-
-
-
-
 }

--- a/tests/Xi/Tests/Filelib/Linker/LinkerTest.php
+++ b/tests/Xi/Tests/Filelib/Linker/LinkerTest.php
@@ -11,9 +11,11 @@ namespace Xi\Tests\Filelib\Linker;
 
 use Xi\Tests\Filelib\TestCase;
 
+/**
+ * @group linker
+ */
 class LinkerTest extends TestCase
 {
-    
     /**
      * @test
      */
@@ -21,6 +23,4 @@ class LinkerTest extends TestCase
     {
         $this->assertTrue(interface_exists('Xi\Filelib\Linker\Linker'));
     }
-    
-    
 }

--- a/tests/Xi/Tests/Filelib/Linker/SequentialLinkerTest.php
+++ b/tests/Xi/Tests/Filelib/Linker/SequentialLinkerTest.php
@@ -12,13 +12,13 @@ namespace Xi\Tests\Filelib\Linker;
 use Xi\Filelib\File\File;
 use Xi\Filelib\Linker\SequentialLinker;
 
+/**
+ * @group linker
+ */
 class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
 {
-
-
     public function setUp()
     {
-
         $fo = $this->getMockBuilder('\Xi\Filelib\Folder\FolderOperator')->getMock();
         $fo->expects($this->any())
              ->method('find')
@@ -70,14 +70,7 @@ class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
 
              }));
 
-
-
         $this->fo = $fo;
-
-
-        $this->filelib = $this->getFilelib();
-
-        $this->filelib->setFolderOperator($fo);
 
         $vp = $this->getMock('\Xi\Filelib\Plugin\VersionProvider\VersionProvider');
         $vp->expects($this->any())
@@ -89,14 +82,8 @@ class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
              ->with('xoo')
              ->will($this->returnValue('xoo'));
 
-
-
         $this->versionProvider = $vp;
-
-
-
     }
-
 
     public function provideFiles()
     {
@@ -131,8 +118,6 @@ class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
         );
     }
 
-
-
     /**
      * @test
      * @dataProvider provideFiles
@@ -143,16 +128,10 @@ class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
         $linker->setDirectoryLevels($levels);
         $linker->setFilesPerDirectory($fpd);
 
-
-        $linker->setFilelib($this->filelib);
-
         $this->assertEquals($beautifurl[0], $linker->getLink($file, true));
-
     }
 
     /**
-     *
-     *
      * @test
      * @dataProvider provideFiles
      */
@@ -162,11 +141,13 @@ class SequentialLinkerTest extends \Xi\Tests\Filelib\TestCase
         $linker->setDirectoryLevels($levels);
         $linker->setFilesPerDirectory($fpd);
 
-        $linker->setFilelib($this->filelib);
-
-        $this->assertEquals($beautifurl[1], $linker->getLinkVersion($file, $this->versionProvider->getIdentifier(), $this->versionProvider->getExtensionFor($this->versionProvider->getIdentifier())));
-
+        $this->assertEquals(
+            $beautifurl[1],
+            $linker->getLinkVersion(
+                $file,
+                $this->versionProvider->getIdentifier(),
+                $this->versionProvider->getExtensionFor($this->versionProvider->getIdentifier())
+            )
+        );
     }
-
-
 }


### PR DESCRIPTION
Started removing stupid dependencies. First on the line is setting `FileLibrary` everywhere. References #56.
