### PR TITLE
Queue processor lets exceptions fall through

### DIFF
--- a/library/Xi/Filelib/Queue/Processor/DefaultQueueProcessor.php
+++ b/library/Xi/Filelib/Queue/Processor/DefaultQueueProcessor.php
@@ -2,15 +2,9 @@
 
 namespace Xi\Filelib\Queue\Processor;
 
-use Xi\Filelib\FileLibrary;
-use Xi\Filelib\FileLibrary\File\FileOperator;
-use Xi\Filelib\FileLibrary\Folder\FolderOperator;
-use Xi\Filelib\Queue\Queue;
 use Xi\Filelib\Queue\Message;
 use Xi\Filelib\Command;
-use ReflectionObject;
 use InvalidArgumentException;
-use Xi\Filelib\FilelibException;
 
 /**
  * Default implementation of a queue processor
@@ -20,7 +14,7 @@ class DefaultQueueProcessor extends AbstractQueueProcessor
     /**
      * Processes a single message from the queue
      *
-     * @return mixed
+     * @return boolean False if there are no messages in the queue.
      */
     public function process()
     {
@@ -29,38 +23,38 @@ class DefaultQueueProcessor extends AbstractQueueProcessor
         $message = $queue->dequeue();
 
         if (!$message) {
-            return null;
+            return false;
         }
 
         $command = $this->extractCommandFromMessage($message);
 
-        return $this->tryToProcess($message, function(DefaultQueueProcessor $processor) use ($command) {
+        $this->processMessage($message, function(DefaultQueueProcessor $processor) use ($command) {
             $processor->injectOperators($command);
-            return $command->execute();
+            $command->execute();
         });
+
+        return true;
     }
 
     /**
-     * Tries to process a message with a processor function
+     * Processes a message with a processor function
      *
-     * @param Message $message
+     * Any exceptions thrown here are left for the caller to handle.
+     *
+     * TODO: Messages should be acked (and maybe logged?) when an exception is
+     *       thrown.
+     *
+     * @param Message  $message
      * @param callable $processorFunction
-     * @return boolean Success or not
      */
-    public function tryToProcess(Message $message, $processorFunction)
+    public function processMessage(Message $message, $processorFunction)
     {
-        try {
-            $ret = $processorFunction($this);
-            $this->getQueue()->ack($message);
+        $ret = $processorFunction($this);
 
-            if ($ret instanceof Command) {
-                $this->getQueue()->enqueue(new Message(serialize($ret)));
-            }
+        $this->getQueue()->ack($message);
 
-            return true;
-
-        } catch (FilelibException $e) {
-            return false;
+        if ($ret instanceof Command) {
+            $this->getQueue()->enqueue(new Message(serialize($ret)));
         }
     }
 
@@ -79,7 +73,4 @@ class DefaultQueueProcessor extends AbstractQueueProcessor
         }
         return $command;
     }
-
-
 }
-

--- a/tests/Xi/Tests/Filelib/Queue/Processor/DefaultQueueProcessorTest.php
+++ b/tests/Xi/Tests/Filelib/Queue/Processor/DefaultQueueProcessorTest.php
@@ -9,7 +9,6 @@ use Xi\Tests\Filelib\Queue\Processor\TestCommand;
 
 class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
 {
-
     protected $queue;
 
     protected $fileOperator;
@@ -36,7 +35,6 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
         $this->filelib = $filelib;
     }
 
-
     /**
      * @test
      */
@@ -46,19 +44,17 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
         $this->assertContains('Xi\Filelib\Queue\Processor\QueueProcessor', class_implements('Xi\Filelib\Queue\Processor\DefaultQueueProcessor'));
     }
 
-
     /**
      * @test
      */
-    public function processShouldExitEarlyIfQueueIsEmpty()
+    public function processReturnsFalseIfQueueIsEmpty()
     {
         $processor = new DefaultQueueProcessor($this->filelib);
 
         $this->queue->expects($this->once())->method('dequeue')->will($this->returnValue(null));
-        $ret = $processor->process();
-        $this->assertNull($ret);
-    }
 
+        $this->assertFalse($processor->process());
+    }
 
     /**
      * @test
@@ -77,14 +73,12 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
     /**
      * @test
      */
-    public function processShouldTryToProcessWhenACommandIsDequeued()
+    public function processShouldProcessMessageWhenACommandIsDequeued()
     {
         $processor = $this->getMockBuilder('Xi\Filelib\Queue\Processor\DefaultQueueProcessor')
                           ->setConstructorArgs(array($this->filelib))
-                          ->setMethods(array('tryToProcess'))
+                          ->setMethods(array('processMessage'))
                           ->getMock();
-
-        // $processor = new DefaultQueueProcessor($this->filelib);
 
         $command = new TestCommand();
 
@@ -92,16 +86,15 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
 
         $this->queue->expects($this->once())->method('dequeue')->will($this->returnValue($message));
 
-        $processor->expects($this->once())->method('tryToProcess');
+        $processor->expects($this->once())->method('processMessage')->with($message);
 
         $processor->process();
-
     }
 
-    /**
-     * @test
-     */
-    public function tryToProcessShouldReturnFalseWhenProcessorFunctionThrowsException()
+     /**
+      * @test
+      */
+    public function processMessageDoesNotCatchExceptionFromProcessorFunction()
     {
         $processor = new DefaultQueueProcessor($this->filelib);
 
@@ -111,16 +104,18 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
 
         $message = new Message(serialize('Tussihofen'));
 
-        $ret = $processor->tryToProcess($message, $processorFunc);
+        $this->setExpectedException(
+            'Xi\Filelib\FilelibException',
+            'Lussen lussen luu!'
+        );
 
-        $this->assertFalse($ret);
-
+        $processor->processMessage($message, $processorFunc);
     }
 
     /**
      * @test
      */
-    public function tryToProcessShouldAckMessageWhenProcessorFunctionDoesntThrowException()
+    public function processMessageShouldAckMessageWhenProcessorFunctionDoesntThrowException()
     {
         $processor = new DefaultQueueProcessor($this->filelib);
 
@@ -132,16 +127,13 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
 
         $this->queue->expects($this->once())->method('ack')->with($this->equalTo($message));
 
-        $ret = $processor->tryToProcess($message, $processorFunc);
-
-        $this->assertTrue($ret);
+        $processor->processMessage($message, $processorFunc);
     }
-
 
     /**
      * @test
      */
-    public function tryToProcessShouldEnqueeWhenProcessorFunctionReturnsANewCommand()
+    public function processMessageShouldEnqueeWhenProcessorFunctionReturnsANewCommand()
     {
         $processor = new DefaultQueueProcessor($this->filelib);
 
@@ -155,18 +147,13 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
 
         $this->queue->expects($this->once())->method('enqueue')->with($this->isInstanceOf('Xi\Filelib\Queue\Message'));
 
-        $ret = $processor->tryToProcess($message, $processorFunc);
-
-        $this->assertTrue($ret);
+        $processor->processMessage($message, $processorFunc);
     }
-
-
-
 
     /**
      * @test
      */
-    public function tryToProcessShouldExecuteCommand()
+    public function processMessageShouldExecuteCommand()
     {
         $processor = $this->getMockBuilder('Xi\Filelib\Queue\Processor\DefaultQueueProcessor')
                           ->setConstructorArgs(array($this->filelib))
@@ -201,7 +188,6 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
         $processor = new DefaultQueueProcessor($this->filelib);
 
         $processor->extractCommandFromMessage($message);
-
     }
 
     /**
@@ -217,9 +203,5 @@ class DefaultQueueProcessorTest extends \Xi\Tests\Filelib\TestCase
         $ret = $processor->extractCommandFromMessage($message);
 
         $this->assertInstanceOf('Xi\Tests\Filelib\Queue\Processor\TestCommand', $ret);
-
     }
-
-
 }
-


### PR DESCRIPTION
Queue processor now lets exceptions thrown in `$processorFunction` fall through. `DefaultQueueProcessor::process` now returns `false` when there are no more messages in the queue.
