### PR TITLE
Fix memcache test when extension not installed

### DIFF
--- a/tests/Xi/Filelib/Tests/Backend/Cache/Adapter/MemcachedCacheAdapterTest.php
+++ b/tests/Xi/Filelib/Tests/Backend/Cache/Adapter/MemcachedCacheAdapterTest.php
@@ -35,6 +35,10 @@ class MemcachedCacheAdapterTest extends TestCase
 
     public function tearDown()
     {
+        if (empty($this->memcached)) {
+            return;
+        }
+
         $this->memcached->flush();
     }
 


### PR DESCRIPTION
Don't try to flush() when memcache not instantiated.

It was causing `Fatal error: Call to a member function flush() on null` when memcache extension is not installed, because tearDown was still executed